### PR TITLE
New unit file needs requirement on db connector

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Process this file with autoconf to produce a configure script.
-AC_INIT([VOMS MySQL plugin], [3.1.7])
+AC_INIT([VOMS MySQL plugin], [3.1.8])
 AC_PREREQ(2.57)
 AC_PREFIX_DEFAULT("/")
 AC_CONFIG_AUX_DIR([./aux])

--- a/spec/voms-mysql-plugin.spec
+++ b/spec/voms-mysql-plugin.spec
@@ -1,5 +1,5 @@
 Name:		voms-mysql-plugin
-Version:	3.1.7
+Version:	3.1.8
 Release:	1%{?dist}
 Summary:	VOMS server plugin for MySQL
 

--- a/systemd/voms@.service.d/after-mariadb.conf
+++ b/systemd/voms@.service.d/after-mariadb.conf
@@ -1,0 +1,3 @@
+## Ensures that VOMS starts after MySQL db is loaded
+[Unit]
+After=mariadb.service


### PR DESCRIPTION
 - created systemd/system/voms@.service.d/after-mariadb.conf
 - added it to voms-mysql-plugin.spec

fix: https://github.com/italiangrid/voms/issues/84